### PR TITLE
Improve compatibility with later version of spaCy (>= 3.0)

### DIFF
--- a/spodernet/preprocessing/processors.py
+++ b/spodernet/preprocessing/processors.py
@@ -17,7 +17,7 @@ import pickle
 from spodernet.utils.logger import Logger
 log = Logger('processors.py.txt')
 
-nlp = spacy.load('en')
+nlp = spacy.load('en_core_web_sm')
 timer = Timer()
 
 class KeyToKeyMapper(IAtBatchPreparedObservable):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1238,7 +1238,7 @@ test_data = [(lambda x: x.ent_type_, NERTokenizer),
 ids = ['NER', 'POS', 'DEP']
 @pytest.mark.parametrize("spacy_func, class_value", test_data, ids=ids)
 def test_spacy_tokenization(spacy_func, class_value):
-    nlp = spacy.load('en')
+    nlp = spacy.load('en_core_web_sm')
     s = DatasetStreamer()
     s.set_path(get_test_data_path_dict()['snli10'])
     s.add_stream_processor(JsonLoaderProcessors())


### PR DESCRIPTION
## SOLUTION before merging: After running step 2 of Installation of ConvE(pip install -r requirements.txt), modify the python code in ConvE/src/spodernet according to the "Files changed" in this PR.

```python
Traceback (most recent call last):
  File "main.py", line 16, in <module>
    from spodernet.preprocessing.pipeline import Pipeline, DatasetStreamer
  File "/root/ConvE/src/spodernet/spodernet/preprocessing/pipeline.py", line 11, in <module>
    from spodernet.preprocessing.processors import SaveLengthsToState
  File "/root/ConvE/src/spodernet/spodernet/preprocessing/processors.py", line 20, in <module>
    nlp = spacy.load('en')
  File "/root/anaconda3/lib/python3.8/site-packages/spacy/__init__.py", line 54, in load
    return util.load_model(
  File "/root/anaconda3/lib/python3.8/site-packages/spacy/util.py", line 435, in load_model
    raise IOError(Errors.E941.format(name=name, full=OLD_MODEL_SHORTCUTS[name]))  # type: ignore[index]
OSError: [E941] Can't find model 'en'. It looks like you're trying to load a model from a shortcut, which is obsolete as of spaCy v3.0. To load the model, use its full name instead:

nlp = spacy.load("en_core_web_sm")

For more details on the available models, see the models directory: https://spacy.io/models. If you want to create a blank model, use spacy.blank: nlp = spacy.blank("en")
(pytorch) root@host:~/ConvE# python -m spacy download en
⚠ As of spaCy v3.0, shortcuts like 'en' are deprecated. Please use the
full pipeline package name 'en_core_web_sm' instead.
```

It said that the updated version of spaCy does not support shortcuts (said in line: 18 of the output).

There are 2 occurrences where the invalid shortcut is used, and I fixed them.